### PR TITLE
Add support for Django 1.0 and Python 3

### DIFF
--- a/easytag.py
+++ b/easytag.py
@@ -2,7 +2,13 @@ from inspect import getargspec
 from functools import partial, wraps
 
 from django.template import Node
-from django.template.base import parse_bits
+try:
+    from django.template.base import parse_bits
+except ImportError:
+    from django.template.library import parse_bits  # Django 1.10
+
+if 'unicode' not in globals():  # Python 3
+    unicode = str
 
 class EasyTag(Node):
     name = None


### PR DESCRIPTION
Hi @tiliv,

I've made some changes in order to be compatible with Django 1.10 and Python 3.

Have you considered pushing `django-easytag` and `django-bootstrap-templatetags` to pypi? They definitely deserve to be out there!

Cheers
